### PR TITLE
Added ability to set the zoom level on a field-by-field basis, using the existing $options argument.

### DIFF
--- a/code/GoogleMapField.php
+++ b/code/GoogleMapField.php
@@ -14,6 +14,7 @@ class GoogleMapField extends FormField {
 				'lat' => 'Lat',
 				'lng' => 'Lng',
 			),
+            'zoom' => 8
 		),
 		$js_inserted = false;
 
@@ -52,7 +53,7 @@ class GoogleMapField extends FormField {
 		$jsOptions = array(
 			'coords' => array($this->getLatData(), $this->getLngData()),
 			'map' => array(
-				'zoom' => 8,
+				'zoom' => $this->getZoomData(),
 				'mapTypeId' => 'ROADMAP',
 			),
 		);
@@ -96,6 +97,10 @@ class GoogleMapField extends FormField {
 		$fieldNames = $this->getOption('fieldNames');
 		return $this->data->$fieldNames['lng'];
 	}
+
+    public function getZoomData() {
+        return $this->options['zoom'];
+    }
 
 	public function getOption($option) {
 		return $this->options[$option];


### PR DESCRIPTION
This adds the ability to use the $options argument to GoogleMapField::__construct() to specify the zoom level of the map when it's first created.

For example:

new GoogleMapField(new Story(array('Lat' => '-41.289996', 'Lng' => '174.784498')), 'Your Location', array('zoom' => 14)).

This will show a zoomed-in view of Wellington, NZ, rather than showing the lower half of the North Island (at the default zoom level of 8).
