### PR TITLE
support for hidden google maps

### DIFF
--- a/javascript/GoogleMapField.js
+++ b/javascript/GoogleMapField.js
@@ -96,7 +96,7 @@
 	}
 
 	function init() {
-		var mapFields = $('.googlemapfield');
+		var mapFields = $('.tab[aria-hidden="false"] .googlemapfield');
 		mapFields.each(initField);
 	}
 
@@ -106,9 +106,9 @@
 		init();
 	}
 
-	// Set the init method to re-run if the page is saved or pjaxed
+	// Set the init method to re-run if the page is saved, pjaxed or a tab switched
 	$.entwine('ss', function($) {
-		$('.googlemapfield').entwine({
+		$('.tab[aria-hidden="false"]').entwine({
 			onmatch: function() {
 				if(gmapsAPILoaded) {
 					init();


### PR DESCRIPTION
Google Maps can not initialize if it is not visible since `$.entwine` does not support
the `:has` selector, and we do not know in which tab the map is located.

The only way to get this working (afaik) is to re-init the current tab on every tab switch. To limit the
performance loss, the `init` function will only act on `GoogleMapField`s in non-hidden tabs.
