### PR TITLE
'Fixes' jquery-ui tabs breaking map layout

### DIFF
--- a/javascript/GoogleMapField.js
+++ b/javascript/GoogleMapField.js
@@ -124,6 +124,20 @@
 					}
 				}
 			});
+			$('.cms-tabset-nav-primary li').entwine({
+				onclick: function() {
+					if(gmapsAPILoaded) {
+						init();
+					}
+				}
+			});
+			$('.ss-tabset li').entwine({
+				onclick: function() {
+					if(gmapsAPILoaded) {
+						init();
+					}
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
This makes it so that you can have multiple map fields with each under a different tab. Prior to this, only the instance loaded on screen would display correctly.
