### PR TITLE
Name the configuration

### DIFF
--- a/_config/googlemapfield.yml
+++ b/_config/googlemapfield.yml
@@ -1,3 +1,6 @@
+---
+Name: googlemapfield
+---
 GoogleMapField:
   default_options:
     api_key: null


### PR DESCRIPTION
So it is possible to use the config after rule for overriding configuration.

Example:

```

---
Name: googlemapfieldoverride
After:
  - '#googlemapfield'

---
GoogleMapField:
  default_options:
    map:
      zoom: 10
    default_field_values:
      Latitude: 58.14
      Longitude: 22.30
```
