### PR TITLE
BUG Fix changes being detected on value initialisation

### DIFF
--- a/client/js/GoogleMapField.js
+++ b/client/js/GoogleMapField.js
@@ -44,18 +44,22 @@
 
 			latField.val(latCoord);
 			lngField.val(lngCoord);
-			updateBounds();
+			updateBounds(init);
 
+			// Mark form as changed if this isn't initialisation
 			if (!init) {
-				// Mark as changed(?)
 				$('.cms-edit-form').addClass('changed');
 			}
 		}
 
-		function updateZoom() {
+		function updateZoom(init) {
 			zoomField.val(map.getZoom());
+			// Mark form as changed if this isn't initialisation
+			if (!init) {
+				$('.cms-edit-form').addClass('changed');
+			}
 		}
-		
+
 		function updateBounds() {
 			var bounds = JSON.stringify(map.getBounds().toJSON());
 			boundsField.val(bounds);
@@ -101,7 +105,7 @@
 		// Populate the fields to the current centre
 		google.maps.event.addListenerOnce(map, 'idle', function(){
 			updateField(map.getCenter(), true);
-			updateZoom();
+			updateZoom(init);
 		});
 
 		google.maps.event.addListener(marker, 'dragend', centreOnMarker);

--- a/src/GoogleMapField.php
+++ b/src/GoogleMapField.php
@@ -108,24 +108,24 @@ class GoogleMapField extends FormField {
 			$name.'[Latitude]',
 			'Lat',
 			$this->recordFieldData('Latitude')
-		)->addExtraClass('googlemapfield-latfield');
+		)->addExtraClass('googlemapfield-latfield no-detect-changes');
 
 		$this->lngField = HiddenField::create(
 			$name.'[Longitude]',
 			'Lng',
 			$this->recordFieldData('Longitude')
-		)->addExtraClass('googlemapfield-lngfield');
+		)->addExtraClass('googlemapfield-lngfield no-detect-changes');
 
 		$this->zoomField = HiddenField::create(
 			$name.'[Zoom]',
 			'Zoom',
 			$this->recordFieldData('Zoom')
-		)->addExtraClass('googlemapfield-zoomfield');
+		)->addExtraClass('googlemapfield-zoomfield no-detect-changes');
 		$this->boundsField = HiddenField::create(
 			$name.'[Bounds]',
 			'Bounds',
 			$this->recordFieldData('Bounds')
-		)->addExtraClass('googlemapfield-boundsfield');
+		)->addExtraClass('googlemapfield-boundsfield no-detect-changes');
 		$this->children = new FieldList(
 			$this->latField,
 			$this->lngField,


### PR DESCRIPTION
If fields did not have a value when the form first loaded, the CMS would detect changes as the fields would have their values changed to an initial value when the map loaded. This meant that when navigating away from a form in the CMS which had a map field that hadn't been interacted with (and hadn't had it's values saved before) you would get a warning about unsaved changes.